### PR TITLE
feat: support inline ignore

### DIFF
--- a/pkg/kustomization/reference_loader_test.go
+++ b/pkg/kustomization/reference_loader_test.go
@@ -14,6 +14,7 @@ func TestReferenceLoader(t *testing.T) {
 		{name: "invalid references", path: "testdata/invalid_reference/", wantErr: true},
 		{name: "unreferenced file", path: "testdata/unreferenced/", wantErr: true},
 		{name: "excludes", path: "testdata/unreferenced/", excludes: []string{"file3.yaml", "file4.yaml"}},
+		{name: "inline ignore", path: "testdata/inline_ignore/"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/kustomization/testdata/inline_ignore/base/file.yaml
+++ b/pkg/kustomization/testdata/inline_ignore/base/file.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example

--- a/pkg/kustomization/testdata/inline_ignore/base/ignored_file.yaml
+++ b/pkg/kustomization/testdata/inline_ignore/base/ignored_file.yaml
@@ -1,0 +1,7 @@
+# kustomize-lint:ignore
+# This file is temporarily disabled but we want to keep it in the repo
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: disabled-config

--- a/pkg/kustomization/testdata/inline_ignore/base/ignored_file2.yaml
+++ b/pkg/kustomization/testdata/inline_ignore/base/ignored_file2.yaml
@@ -1,0 +1,7 @@
+---
+# TODO: Re-enable this when feature is ready
+# kustomize-lint:ignore - temporarily disabled
+apiVersion: v1
+kind: Secret
+metadata:
+  name: disabled-secret

--- a/pkg/kustomization/testdata/inline_ignore/base/kustomization.yaml
+++ b/pkg/kustomization/testdata/inline_ignore/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - file.yaml
+  # - ignored_file.yaml


### PR DESCRIPTION
sometimes desirable to keep a file in the repo -- inline ignore is less prone to issues than a top-level exclude (if you look in the repo there's currently files excluded from linting that are no longer even in the repo, so it can easily get stale)