### PR TITLE
feat: compare path against cleaned filepath to detect whitespace issues

### DIFF
--- a/cmd/kustomize-lint/main.go
+++ b/cmd/kustomize-lint/main.go
@@ -41,13 +41,14 @@ type CLI struct {
 }
 
 type LintCmd struct {
-	Path     string   `arg:"" name:"path" help:"Path to validate." type:"path"`
-	Excludes []string `name:"exclude" short:"x" help:"Exclude files matching the given glob patterns."`
+	Path            string   `arg:"" name:"path" help:"Path to validate." type:"path"`
+	Excludes        []string `name:"exclude" short:"x" help:"Exclude files matching the given glob patterns."`
+	StrictPathCheck bool     `name:"strict-path-check" short:"s" help:"Enable strict path checking mode"`
 }
 
 func (cmd *LintCmd) Run(globals *Globals) error {
 	cmd.Excludes = append(cmd.Excludes, "README.md", ".gitignore")
-	referenceLoader := kustomization.NewReferenceLoader(cmd.Excludes...)
+	referenceLoader := kustomization.NewReferenceLoader(cmd.StrictPathCheck, cmd.Excludes...)
 
 	if err := referenceLoader.Validate(cmd.Path); err != nil {
 		log.Fatal("Validation errors", "err", err)

--- a/pkg/kustomization/reference_loader_test.go
+++ b/pkg/kustomization/reference_loader_test.go
@@ -4,10 +4,11 @@ import "testing"
 
 func TestReferenceLoader(t *testing.T) {
 	tests := []struct {
-		name     string
-		path     string
-		excludes []string
-		wantErr  bool
+		name            string
+		path            string
+		excludes        []string
+		strictPathCheck bool
+		wantErr         bool
 	}{
 		{name: "valid", path: "testdata/valid/"},
 		{name: "invalid", path: "testdata/invalid/", wantErr: true},
@@ -15,11 +16,13 @@ func TestReferenceLoader(t *testing.T) {
 		{name: "unreferenced file", path: "testdata/unreferenced/", wantErr: true},
 		{name: "excludes", path: "testdata/unreferenced/", excludes: []string{"file3.yaml", "file4.yaml"}},
 		{name: "inline ignore", path: "testdata/inline_ignore/"},
+		{name: "strict paths enabled", path: "testdata/strict_paths/", strictPathCheck: true, wantErr: true},
+		{name: "strict paths disabled", path: "testdata/strict_paths/", strictPathCheck: false, wantErr: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := NewReferenceLoader(tt.excludes...).Validate(tt.path)
+			err := NewReferenceLoader(tt.strictPathCheck, tt.excludes...).Validate(tt.path)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/kustomization/testdata/strict_paths/base/kustomization.yaml
+++ b/pkg/kustomization/testdata/strict_paths/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - resource.yaml
+  - https://github.com/kubernetes-sigs/kustomize//examples/multibases?timeout=120&ref=v3.3.1

--- a/pkg/kustomization/testdata/strict_paths/base/resource.yaml
+++ b/pkg/kustomization/testdata/strict_paths/base/resource.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: base1

--- a/pkg/kustomization/testdata/strict_paths/overlays/prod1/kustomization.yaml
+++ b/pkg/kustomization/testdata/strict_paths/overlays/prod1/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+    - ../../shared/prod
+  - resource.yaml

--- a/pkg/kustomization/testdata/strict_paths/overlays/prod1/resource.yaml
+++ b/pkg/kustomization/testdata/strict_paths/overlays/prod1/resource.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prod1

--- a/pkg/kustomization/testdata/strict_paths/shared/prod/kustomization.yaml
+++ b/pkg/kustomization/testdata/strict_paths/shared/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - resource.yaml

--- a/pkg/kustomization/testdata/strict_paths/shared/prod/resource.yaml
+++ b/pkg/kustomization/testdata/strict_paths/shared/prod/resource.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sharedprod1


### PR DESCRIPTION
compare the `file` from YAML to what's processed as the cleaned filepath and fail if the two do not match -- this can catch issues with whitespace alignment that cause kustomize to eat up reference files the end-user doesn't intend to remove (https://github.com/kubernetes-sigs/kustomize/issues/5979)

put this behind a flag (`--strict-path-check`) as kustomize will still work in instances where a user has added a trailing `/` to a directory, for example 