### PR TITLE
chore: update README with file ignores and strict path checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,47 @@ FATA Validation errors err="reference \"file.yaml\" cannot be loaded and does no
 exit status 1
 ```
 
+#### Ignoring Files
+
+To explicitly ignore files that are not referenced, the `--exclude` (`-x`) flag can be provided or an inline `# kustomize-lint:ignore` comment can be added to the file.
+
+For example, with this directory structure:
+```
+$ cat kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - file.yaml
+  # - ignored_file.yaml
+$ ls
+file.yaml  ignored_file.yaml  kustomization.yaml
+```
+
+The lint will fail:
+```
+$ kustomize-lint .
+FATA Validation errors err="* resource \"ignored_file.yaml\" not referenced"
+```
+
+Exclude it with a command-line flag:
+```
+$ kustomize-lint -x ignored_file.yaml
+```
+
+Or, by adding the `# kustomize-lint:ignore` comment within the first 10 lines of the file:
+```
+$ head ignored_file.yaml
+# kustomize-lint:ignore
+# This file is temporarily disabled but we want to keep it in the repo
+---
+apiVersion: v1
+kind: ConfigMap
+```
+
+#### Strict File Checking
+
+To workaround [kubernetes/kustomize#5979](https://github.com/kubernetes-sigs/kustomize/issues/5979), the `--strict-path-check` (`-s`) flag will fail if a file reference does not match the output of [`filepath.Clean`](https://pkg.go.dev/path/filepath#Clean).
+
 #### Debugging
 
 To output more information, provide the `--debug` flag:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates README to document ignoring unreferenced files and strict path checking, with examples and CLI flags.
> 
> - **Docs (README)**:
>   - **Ignoring files**: Add guidance on excluding unreferenced files via `--exclude` (`-x`) or inline `# kustomize-lint:ignore` within the first 10 lines, with usage examples.
>   - **Strict file checking**: Document `--strict-path-check` (`-s`) to fail on non-`filepath.Clean` references, with link to upstream issue.
>   - **Examples/structure**: Add example directory, commands, and reposition debugging section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c8fbcfc05db5e7dcd36c2523016526e36f407c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->